### PR TITLE
[SVN] fix codegen in lp-build*

### DIFF
--- a/src/TeXmacs/progs/utils/literate/lp-build.scm
+++ b/src/TeXmacs/progs/utils/literate/lp-build.scm
@@ -174,7 +174,7 @@
     (for (key (map car (ahash-table->list t)))
       (let* ((l (tm-children (tm->stree (ahash-ref t key))))
              (c (map (lambda (x)
-                       (convert x "texmacs-stree" "verbatim-document")) l))
+                       (texmacs->code x "SourceCode")) l))
              (i (map (cut string-append <> "\n") c)))
         (ahash-set! r key (apply string-append i))))
     r))


### PR DESCRIPTION
before fixing:
```
(list `a `b `c)
```
will be convert to
```
(list ‘a ‘b ‘c)
```