### PR TITLE
Must use move_accessible when moving the cursor during editing

### DIFF
--- a/src/src/Data/Tree/tree_traverse.cpp
+++ b/src/src/Data/Tree/tree_traverse.cpp
@@ -350,7 +350,7 @@ move_node (tree t, path p, bool forward) {
     if (forward) p= path_up (p) * N (st->label);
     else p= path_up (p) * 0;
   }
-  p= move_valid (t, p, forward);
+  p= move_accessible (t, p, forward);
   st= subtree (t, path_up (p));
   if (is_atomic (st) && last_item (p) > 0)
     p= path_up (p) * N (st->label);


### PR DESCRIPTION
When using the toolbar arrows to move to the next or previous similar tag, it crashes without this patch. I can upload a video demonstration to youtube if you like.