### PR TITLE
Implement page-fnote-barsep to improve appearance

### DIFF
--- a/src/TeXmacs/packages/environment/env-float.ts
+++ b/src/TeXmacs/packages/environment/env-float.ts
@@ -1,4 +1,4 @@
-<TeXmacs|1.99.2>
+<TeXmacs|1.99.4>
 
 <style|source>
 
@@ -113,7 +113,7 @@
   </active*>
 
   <assign|render-footnote*|<macro|sym|nr|body|<style-with|src-compact|none|<\float|footnote|>
-    <smaller|<with|par-mode|justify|par-left|0cm|par-right|0cm|font-shape|right|dummy|<value|page-fnote-sep>|dummy|<value|page-fnote-barlen>|<style-with|src-compact|none|<surround|<locus|<id|<hard-id|<arg|body>>>|<link|hyperlink|<id|<hard-id|<arg|body>>>|<url|<merge|#footnr-|<arg|nr>>>>|<arg|sym>><footnote-sep>|<set-binding|<merge|footnote-|<arg|nr>>|<value|the-label>|body><right-flush>|<style-with|src-compact|none|<arg|body>>>>>>
+    <smaller|<with|par-mode|justify|par-left|0cm|par-right|0cm|font-shape|right|dummy|<value|page-fnote-sep>|dummy|<value|page-fnote-barlen>|dummy|<value|page-fnote-barsep>|dummy|<value|par-fnote-sep>|<style-with|src-compact|none|<surround|<locus|<id|<hard-id|<arg|body>>>|<link|hyperlink|<id|<hard-id|<arg|body>>>|<url|<merge|#footnr-|<arg|nr>>>>|<arg|sym>><footnote-sep>|<set-binding|<merge|footnote-|<arg|nr>>|<value|the-label>|body><right-flush>|<style-with|src-compact|none|<arg|body>>>>>>
   </float>>>>
 
   <assign|render-footnote|<macro|nr|body|<render-footnote*|<arg|nr>|<arg|nr>|<arg|body>>>>

--- a/src/src/Data/Drd/drd_std.cpp
+++ b/src/src/Data/Drd/drd_std.cpp
@@ -1041,6 +1041,7 @@ init_std_drd () {
   init_var (PAGE_SHOW_HF, TYPE_BOOLEAN);
   init_var (PAGE_FNOTE_SEP, TYPE_LENGTH);
   init_var (PAGE_FNOTE_BARLEN, TYPE_LENGTH);
+  init_var (PAGE_FNOTE_BARSEP, TYPE_LENGTH);
   init_var (PAGE_FLOAT_SEP, TYPE_LENGTH);
   init_var (PAGE_FLOAT_ENABLE, TYPE_BOOLEAN);
   init_var (PAGE_MNOTE_SEP, TYPE_LENGTH);

--- a/src/src/Data/Drd/vars.cpp
+++ b/src/src/Data/Drd/vars.cpp
@@ -160,6 +160,7 @@ string PAGE_SCREEN_BOT ("page-screen-bot");
 string PAGE_SHOW_HF ("page-show-hf");
 string PAGE_FNOTE_SEP ("page-fnote-sep");
 string PAGE_FNOTE_BARLEN ("page-fnote-barlen");
+string PAGE_FNOTE_BARSEP ("page-fnote-barsep");
 string PAGE_FLOAT_SEP ("page-float-sep");
 string PAGE_FLOAT_ENABLE ("page-float-enable");
 string PAGE_MNOTE_SEP ("page-mnote-sep");

--- a/src/src/Data/Drd/vars.hpp
+++ b/src/src/Data/Drd/vars.hpp
@@ -150,6 +150,7 @@ extern string PAGE_SCREEN_BOT;
 extern string PAGE_SHOW_HF;
 extern string PAGE_FNOTE_SEP;
 extern string PAGE_FNOTE_BARLEN;
+extern string PAGE_FNOTE_BARSEP;
 extern string PAGE_FLOAT_SEP;
 extern string PAGE_FLOAT_ENABLE;
 extern string PAGE_MNOTE_SEP;

--- a/src/src/Typeset/Env/env_default.cpp
+++ b/src/src/Typeset/Env/env_default.cpp
@@ -167,6 +167,7 @@ initialize_default_env () {
   env (PAGE_SHOW_HF)     = "true";      // show header and footer
   env (PAGE_FNOTE_SEP)   = "1.0fn";     // space between text & footnotes
   env (PAGE_FNOTE_BARLEN)= "7.5fn";     // length of footnote separating bar
+  env (PAGE_FNOTE_BARSEP)= "0.2fn";     // space between separating bar and first footnote
   env (PAGE_FLOAT_SEP)   = "1.5fn";     // space between text & floats
   env (PAGE_FLOAT_ENABLE)= "paper";     // enable floating objects
   env (PAGE_MNOTE_SEP)   = "5mm";       // space between text & marginal notes

--- a/src/src/Typeset/Page/make_pages.cpp
+++ b/src/src/Typeset/Page/make_pages.cpp
@@ -151,7 +151,7 @@ pager_rep::pages_format (pagelet pg) {
       pencil pen= env->pen->set_width (env->fn->wline);
       bs << line_box (decorate(), 0, 0, fnote_bl, 0, pen);
       bx << 0;
-      by << (fnote_y + env->fn->sep);
+      by << (fnote_y + stretch_space (fnote_bs, 0.5));
     }
     // cout << UNINDENT << "Formatted pagelet " << (N(pages)+1) << LF << LF;
     return scatter_box (ip, bs, bx, by);

--- a/src/src/Typeset/Page/pager.cpp
+++ b/src/src/Typeset/Page/pager.cpp
@@ -42,6 +42,7 @@ pager_rep::pager_rep (path ip2, edit_env env2, array<page_item> l2):
   fn_sep    = env->get_vspace (PAR_FNOTE_SEP);
   fnote_sep = env->get_vspace (PAGE_FNOTE_SEP) + (2*env->fn->sep);
   fnote_bl  = env->get_length (PAGE_FNOTE_BARLEN);
+  fnote_bs  = env->get_length (PAGE_FNOTE_BARSEP) + (2*env->fn->sep);
   float_sep = env->get_vspace (PAGE_FLOAT_SEP);
   mnote_sep = env->get_length (PAGE_MNOTE_SEP);
   show_hf   = env->get_bool (PAGE_SHOW_HF) && paper;

--- a/src/src/Typeset/Page/pager.hpp
+++ b/src/src/Typeset/Page/pager.hpp
@@ -45,6 +45,7 @@ public:
   space        fn_sep;
   space        fnote_sep;
   SI           fnote_bl;
+  SI           fnote_bs;
   space        float_sep;
   SI           mnote_sep;
 


### PR DESCRIPTION
Implement page-fnote-barsep to improve appearance.

Use 2*env->fn->sep below the footnote line because the footnotes are too close
to the bar otherwise, especially when the footnote font size is the same as the
body text, as is required by some court's legal brief styles. By doubling
env->fn->sep, it looks good with either small or normal-size footnotes.