### PR TITLE
[SVN] Fix date for Chinese

### DIFF
--- a/src/src/System/Language/text_language.cpp
+++ b/src/src/System/Language/text_language.cpp
@@ -629,11 +629,9 @@ get_date (string lan, string fm) {
 	string y= simplify_date (var_eval_system ("date +\"%Y\""));
 	string m= simplify_date (var_eval_system ("date +\"%m\""));
 	string d= simplify_date (var_eval_system ("date +\"%d\""));
-	if (lan == "japanese")
-	  return y * "<#5e74>" * m * "<#6708>" * d * "<#65e5>";
 	if (lan == "korean")
 	  return y * "<#b144> " * m * "<#c6d4> " * d * "<#c77c>";
-	return y * "," * m * "," * d;
+	return y * "<#5e74>" * m * "<#6708>" * d * "<#65e5>";
       }
     else fm= "%d %B %Y";
   }


### PR DESCRIPTION
Chinese uses the same format (and same unicode) as Japanese, so we only have to check if the language is Korean.