### PR TITLE
[SVN] Make texmacs_body static; Fix link order

### DIFF
--- a/src/src/CMakeLists.txt
+++ b/src/src/CMakeLists.txt
@@ -1,13 +1,13 @@
 
-add_library(texmacs_body ${TeXmacs_All_SRCS})
+add_library(texmacs_body STATIC ${TeXmacs_All_SRCS})
 
 add_executable (${TeXmacs_binary_name}
   ./Texmacs/Texmacs/texmacs.cpp
 )
 
 target_link_libraries (${TeXmacs_binary_name}
-  ${TeXmacs_Libraries}
   texmacs_body
+  ${TeXmacs_Libraries}
 )
 
 #--------------------------------------------------------------------------------


### PR DESCRIPTION
texmacs_body is a convenience library - declare it to be static.  Needs to be linked first.